### PR TITLE
Transform date-fns/locale imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export default ({ types: t }) => ({
       const { specifiers, source } = node;
       const { value: pkgId } = source;
 
-      if (pkgId !== 'date-fns') {
+      if (pkgId !== 'date-fns' && pkgId !== 'date-fns/locale') {
         return;
       }
 
@@ -17,13 +17,17 @@ export default ({ types: t }) => ({
         const { local, imported } = spec;
         const { name: localName } = local;
 
-        let importedPath = 'date-fns';
+        let importedPath = pkgId;
 
         if (t.isImportSpecifier(spec)) {
-          const { name: importedName } = imported;
+          let { name: importedName } = imported;
           spec = t.importDefaultSpecifier(t.identifier(localName));
 
-          importedPath = `date-fns/${importedName}`;
+          if (pkgId === 'date-fns/locale') {
+            importedName = importedName.replace(/[A-Z]/, '-$&');
+          }
+
+          importedPath = `${pkgId}/${importedName}`;
         }
 
         path.insertAfter(t.importDeclaration([spec], t.stringLiteral(importedPath)));

--- a/test/fixtures/locales/code.js
+++ b/test/fixtures/locales/code.js
@@ -1,0 +1,5 @@
+import {
+  enUS,
+  srLatn,
+  uk,
+} from "date-fns/locale";

--- a/test/fixtures/locales/output.js
+++ b/test/fixtures/locales/output.js
@@ -1,0 +1,3 @@
+import uk from "date-fns/locale/uk";
+import srLatn from "date-fns/locale/sr-Latn";
+import enUS from "date-fns/locale/en-US";


### PR DESCRIPTION
Transforms

```js
import { enUS, srLatn, uk } from "date-fns/locale";
```

to

```js
import uk from "date-fns/locale/uk";
import srLatn from "date-fns/locale/sr-Latn";
import enUS from "date-fns/locale/en-US";
```

Could be somewhat related to https://github.com/date-fns/babel-plugin-date-fns/issues/8.